### PR TITLE
Процедура postinstall по требованию

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -152,6 +152,10 @@ Dobro.prototype.install = function(path, pack) {
         this._installByNpm(path, pack);
     }
 
+    // Процедура postinstall по требованию
+    if (pack.postinstall) {
+        this._exec(pack.postinstall);
+    }
 };
 
 /**


### PR DESCRIPTION
Для полной процедуры установки зависимостей (например, для git://github.com/bem/bem-mvc требуется ```npm run postinstall```)